### PR TITLE
added caching in user doc

### DIFF
--- a/easyuser/lib/src/widgets/user.doc.dart
+++ b/easyuser/lib/src/widgets/user.doc.dart
@@ -82,6 +82,9 @@ class UserDoc extends StatelessWidget {
         if (snapshot.hasError) {
           return Text(snapshot.error.toString());
         }
+        if (snapshot.data != null) {
+          MemoryCache.instance.create(uid, snapshot.data);
+        }
         return builder(snapshot.data);
       },
     );


### PR DESCRIPTION
User doc dart is not caching, that is why we have some quick blink in chat room screen.

Adding a MemoryCache in Future Builder in user doc dart to prevent blinkers.